### PR TITLE
[HCR-101] 테스트 빌드 실패 JWT 토큰 필터 제외

### DIFF
--- a/src/test/java/site/holliverse/customer/web/controller/ProductControllerTest.java
+++ b/src/test/java/site/holliverse/customer/web/controller/ProductControllerTest.java
@@ -45,7 +45,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(ProductController.class)
+@WebMvcTest(
+        controllers = ProductController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration.class
+        }
+)
 @ActiveProfiles("customer")
 class ProductControllerTest {
 
@@ -65,6 +71,7 @@ class ProductControllerTest {
     private PlanCompareResponseAssembler planCompareResponseAssembler;
     @MockitoBean
     private ProductResponseMapper mapper;
+    /** SecurityConfig 등 로드 시 필요. JWT 로직은 사용하지 않고 컨텍스트 기동용 목만 둠. */
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
ProductControllerTest에 JWT 로직을 사용하지 않고 
JwtTokenProvider는 MockBean만 유지 
- SecurityConfig → JwtAuthenticationFilter → JwtTokenProvider 때문에 테스트 컨텍스트가 이 빈을 요구함. 
- 실제 JWT 로직 없이 컨텍스트만 뜨도록 @MockitoBean JwtTokenProvider를 두었음 
- 시큐리티 필터 / 인증이 테스트에 개입하지 않아 인증없이 ProductController만 검증한다. 
<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드 , 설정, 구조등 변경을 명시 -->


<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-101

<br/>

## #️⃣관련 이슈

- closes #31 


<br/>
