### PR TITLE
[HCR-233] V21: 유저 행동 로그 테이블 신설 및 상담 분석 아웃박스 설계 리팩토링

### DIFF
--- a/src/main/resources/db/migration/V21__add_athena_log_and_modify_analysis_outbox.sql
+++ b/src/main/resources/db/migration/V21__add_athena_log_and_modify_analysis_outbox.sql
@@ -45,7 +45,10 @@ CREATE TABLE IF NOT EXISTS index_raw_snapshot (
       internet_security_raw numeric NOT NULL,
       stability_raw numeric NOT NULL,
       created_at timestamptz NOT NULL DEFAULT now(),
-      CONSTRAINT pk_index_raw_snapshot PRIMARY KEY (snapshot_date, member_id)
+      CONSTRAINT pk_index_raw_snapshot PRIMARY KEY (snapshot_date, member_id),
+      CONSTRAINT fk_index_raw_snapshot_member
+          FOREIGN KEY (member_id) REFERENCES member (member_id)
+          ON UPDATE CASCADE ON DELETE CASCADE
   );
 CREATE INDEX IF NOT EXISTS idx_index_raw_snapshot_member ON index_raw_snapshot (member_id);
 
@@ -60,7 +63,10 @@ CREATE TABLE IF NOT EXISTS index_tscore_snapshot (
       internet_security_tscore numeric NOT NULL,
       stability_tscore numeric NOT NULL,
       created_at timestamptz NOT NULL DEFAULT now(),
-      CONSTRAINT pk_index_tscore_snapshot PRIMARY KEY (snapshot_date, member_id)
+      CONSTRAINT pk_index_tscore_snapshot PRIMARY KEY (snapshot_date, member_id),
+      CONSTRAINT fk_index_tscore_snapshot_member
+          FOREIGN KEY (member_id) REFERENCES member (member_id)
+          ON UPDATE CASCADE ON DELETE CASCADE
   );
 CREATE INDEX IF NOT EXISTS idx_index_tscore_snapshot_member ON index_tscore_snapshot (member_id);
 


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
**1. 아테나 로그 및 유저 지수 테이블 신설**
- `user_event_features_7d`: 7일/90일 기준 유저 클릭 이벤트 집계 및 JSONB 태그 저장
- `index_raw_snapshot`, `index_tscore_snapshot`, `index_persona_snapshot`: 멤버 지수 및 페르소나 데이터 적재 테이블 추가 (Member 삭제 시 CASCADE 적용)

**2. 상담 분석 내역 ↔ 아웃박스 책임 분리 (Refactoring)**
- `consultation_analysis` 테이블에서 상태 관리(`analysis_status`), 선점 토큰(`claim_token`), 처리 시간(`claimed_started_at` 등) 컬럼 일체 삭제
- 위 컬럼들을 이벤트 발송을 전담하는 `analysis_dispatch_outbox` 테이블로 이관
- 발송 상태 관리를 위한 `dispatch_status` ENUM 신규 도입 ('READY', 'SENT', 'ACKED', 'RETRY', 'DEAD')
- `consultation_analysis`의 기존 단일 티켓 유니크 키(`uk_case_id`) 삭제 후, 버전을 포함한 복합 유니크 키(`uk_case_version`)로 변경하여 다중 분석 내역 관리 지원

<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드 , 설정, 구조등 변경을 명시 -->


<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-233

<br/>

## #️⃣관련 이슈

- closes #153 


<br/>
