### PR TITLE
[HCR-247] 회원 조회 성능 최적화(LATERAL JOIN) 및 요금제 복합 필터링 구현

### DIFF
--- a/src/main/java/site/holliverse/admin/query/dao/AdminMemberDao.java
+++ b/src/main/java/site/holliverse/admin/query/dao/AdminMemberDao.java
@@ -270,17 +270,17 @@ public class AdminMemberDao {
                     .from(PRODUCT)
                     .where(PRODUCT.PRODUCT_CODE.in(req.planNames()));
 
-            // 이 회원이 가진 상품 중, 검색어와 일치하는 상품들의 '대분류' 개수 계산
-            var memberMatchedCategoryCount = DSL.select(DSL.countDistinct(PRODUCT.PRODUCT_TYPE))
+            // 조건에 맞는 회원 ID 집합
+            var matchedMemberIds = DSL.select(SUBSCRIPTION.MEMBER_ID)
                     .from(SUBSCRIPTION)
                     .join(PRODUCT).on(SUBSCRIPTION.PRODUCT_ID.eq(PRODUCT.PRODUCT_ID))
-                    .where(SUBSCRIPTION.MEMBER_ID.eq(MEMBER.MEMBER_ID))
-                    .and(PRODUCT.PRODUCT_CODE.in(req.planNames()));
+                    .where(PRODUCT.PRODUCT_CODE.in(req.planNames())) // 검색된 요금제만 일단 필터링
+                    .groupBy(SUBSCRIPTION.MEMBER_ID)                 // 회원별로 묶기
+                    // 묶은 결과 중에서, 카테고리 개수가 타겟 개수와 똑같은 사람만 남기기
+                    .having(DSL.countDistinct(PRODUCT.PRODUCT_TYPE).eq(targetCategoryCount));
 
-            // [결과] 두 개수가 완벽히 같으면 조건 만족
-            conditions.add(
-                    DSL.field(memberMatchedCategoryCount).eq(DSL.field(targetCategoryCount))
-            );
+            // 메인 쿼리의 회원 ID가, 아까 뽑아둔 "합격자 명단(matchedMemberIds)"에 들어있는가?
+            conditions.add(MEMBER.MEMBER_ID.in(matchedMemberIds));
         }
 
         // 5. 가입 기간 다중 필터링


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
### 1. 관리자 회원 조회 비즈니스 로직 개선

- 회원 목록 및 통계에서 상담사(COUNSELOR) 계정이 노출되지 않도록 `role = 'CUSTOMER'` 기본 필터 고정

- 탈퇴(`DELETED`) 회원 조회 시 과거 구독 및 약정 정보가 정상적으로 표출되도록 구독 조인 조건 완화 (활성화 검사 `.isTrue()` 제거)

### 2. 회원 상세 쿼리 성능 최적화

- 최신 상담 이력(날짜, 상태, 점수)을 가져올 때 `SUPPORT_CASE` 테이블을 3번이나 중복 스캔하던 기존 서브쿼리 구조를 `LATERAL JOIN`으로 변경하여 단 1회 스캔으로 가져오도록 쿼리 튜닝

### 3. 요금제 다중 검색 스마트 필터링 고도화

- 요금제 필터링 시 대분류(Product Type) 간에는 AND, 소분류(상품) 간에는 OR 조건이 유연하게 적용되도록 `COUNT DISTINCT` 교차 검증 로직 도입


<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드 , 설정, 구조등 변경을 명시 -->


<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-247

<br/>

## #️⃣관련 이슈

- closes #165 


<br/>
