### PR TITLE
[HCR-335] 로그 이탈 사유 및 피처 스냅샷 동기화

### DIFF
--- a/src/main/java/site/holliverse/admin/application/usecase/CalculateChurnScoreService.java
+++ b/src/main/java/site/holliverse/admin/application/usecase/CalculateChurnScoreService.java
@@ -5,14 +5,11 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import site.holliverse.admin.application.usecase.dto.AnalysisResponseCommand;
 import site.holliverse.admin.domain.model.churn.ChurnEvaluationResult;
-import site.holliverse.admin.domain.model.churn.ChurnFeatureContribution;
 import site.holliverse.admin.domain.model.churn.ChurnFeatureSet;
 import site.holliverse.admin.domain.model.churn.ChurnFeatureType;
-import site.holliverse.admin.domain.model.churn.ChurnRiskGrade;
 import site.holliverse.admin.domain.model.churn.ChurnSignalType;
 import site.holliverse.admin.domain.model.churn.ChurnScoreCalculationResult;
 import site.holliverse.admin.domain.model.churn.feature.MemberDissatisfactionFeature;
-import site.holliverse.admin.domain.policy.churn.ChurnRiskGradePolicy;
 import site.holliverse.admin.domain.policy.churn.ChurnScorePolicy;
 
 import java.time.LocalDate;
@@ -27,7 +24,7 @@ import java.util.Optional;
 public class CalculateChurnScoreService {
 
     private final ChurnScorePolicy churnScorePolicy;
-    private final ChurnRiskGradePolicy churnRiskGradePolicy;
+    private final ChurnRiskReasonFactory churnRiskReasonFactory;
     private final ChurnSnapshotStoreService churnSnapshotStoreService;
     private final MemberDissatisfactionFeatureSnapshotService memberDissatisfactionFeatureSnapshotService;
 
@@ -48,15 +45,6 @@ public class CalculateChurnScoreService {
         // 점수 계산
         ChurnScoreCalculationResult scoreResult = churnScorePolicy.calculateDetails(featureSet);
 
-        // 등급 계산
-        ChurnRiskGrade riskGrade = churnRiskGradePolicy.classify(scoreResult.score().value());
-
-        // 위험 사유 조립
-        List<ChurnRiskReason> riskReasons = buildCounselRiskReasons(command, scoreResult);
-
-        // 스냅샷 저장
-        churnSnapshotStoreService.store(command.memberId(), baseDate, scoreResult, riskGrade, riskReasons);
-
         // feature 스냅샷 저장
         memberDissatisfactionFeatureSnapshotService.sync(
                 command.memberId(),
@@ -65,8 +53,16 @@ public class CalculateChurnScoreService {
                 scoreResult
         );
 
-        // 결과 반환
-        return new ChurnEvaluationResult(scoreResult, riskGrade);
+        // 위험 사유 조립
+        List<ChurnRiskReason> riskReasons = buildCounselRiskReasons(command, scoreResult);
+
+        // 스냅샷 저장
+        return churnSnapshotStoreService.store(
+                command.memberId(),
+                baseDate,
+                ChurnRiskReason.Feature.COUNSEL,
+                riskReasons
+        );
     }
 
     /**
@@ -95,7 +91,7 @@ public class CalculateChurnScoreService {
             return Optional.empty();
         }
 
-        return createRiskReason(
+        return churnRiskReasonFactory.create(
                 scoreResult,
                 ChurnRiskReason.Feature.COUNSEL,
                 ChurnRiskReason.ReasonCode.NEGATIVE_SENTIMENT,
@@ -137,7 +133,7 @@ public class CalculateChurnScoreService {
             return Optional.empty();
         }
 
-        return createRiskReason(
+        return churnRiskReasonFactory.create(
                 scoreResult,
                 ChurnRiskReason.Feature.COUNSEL,
                 ChurnRiskReason.ReasonCode.KEYWORD,
@@ -146,45 +142,5 @@ public class CalculateChurnScoreService {
                 ChurnRiskReason.ReasonCode.KEYWORD.keywordSummary(keywords),
                 new ChurnRiskReason.KeywordEvidence(keywords)
         );
-    }
-
-    /**
-     * signal 점수.
-     */
-    private int appliedScore(ChurnScoreCalculationResult scoreResult, ChurnSignalType signalType) {
-        return scoreResult.contributions().stream()
-                .filter(contribution -> contribution.signalType() == signalType)
-                .mapToInt(ChurnFeatureContribution::appliedScore)
-                .findFirst()
-                .orElse(0);
-    }
-
-    /**
-     * 사유 생성.
-     */
-    private Optional<ChurnRiskReason> createRiskReason(
-            ChurnScoreCalculationResult scoreResult,
-            ChurnRiskReason.Feature feature,
-            ChurnRiskReason.ReasonCode reasonCode,
-            ChurnSignalType signalType,
-            Object observedValue,
-            String summary,
-            Object evidence
-    ) {
-        int appliedScore = appliedScore(scoreResult, signalType);
-        if (appliedScore <= 0) {
-            return Optional.empty();
-        }
-
-        return Optional.of(new ChurnRiskReason(
-                feature,
-                reasonCode,
-                summary,
-                appliedScore,
-                signalType,
-                signalType.getCollectionType(),
-                observedValue,
-                evidence
-        ));
     }
 }

--- a/src/main/java/site/holliverse/admin/application/usecase/CalculateLogChurnScoreService.java
+++ b/src/main/java/site/holliverse/admin/application/usecase/CalculateLogChurnScoreService.java
@@ -1,0 +1,146 @@
+package site.holliverse.admin.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import site.holliverse.admin.domain.model.churn.ChurnEvaluationResult;
+import site.holliverse.admin.domain.model.churn.ChurnFeatureSet;
+import site.holliverse.admin.domain.model.churn.ChurnFeatureType;
+import site.holliverse.admin.domain.model.churn.ChurnScoreCalculationResult;
+import site.holliverse.admin.domain.model.churn.ChurnSignalType;
+import site.holliverse.admin.domain.model.churn.feature.MemberActionFeature;
+import site.holliverse.admin.domain.policy.churn.ChurnScorePolicy;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 로그 이탈 계산 서비스.
+ */
+@Service
+@Profile("admin")
+@RequiredArgsConstructor
+public class CalculateLogChurnScoreService {
+
+    private final ChurnScorePolicy churnScorePolicy;
+    private final ChurnRiskReasonFactory churnRiskReasonFactory;
+    private final ChurnSnapshotStoreService churnSnapshotStoreService;
+    private final MemberActionFeatureSnapshotService memberActionFeatureSnapshotService;
+
+    /**
+     * 로그 스냅샷 계산.
+     */
+    public ChurnEvaluationResult calculateAndStore(
+            Long memberId,
+            LocalDate baseDate,
+            List<LogFeatureEvent> events
+    ) {
+        // 스냅샷 준비
+        MemberActionFeatureSnapshotService.SnapshotContext snapshotContext =
+                memberActionFeatureSnapshotService.prepare(memberId, events);
+
+        // feature 조립
+        ChurnFeatureSet featureSet = new ChurnFeatureSet(Map.of(
+                ChurnFeatureType.MEMBER_ACTION,
+                snapshotContext.feature()
+        ));
+
+        // 점수 계산
+        ChurnScoreCalculationResult scoreResult = churnScorePolicy.calculateDetails(featureSet);
+
+        // feature 스냅샷 저장
+        memberActionFeatureSnapshotService.sync(snapshotContext, scoreResult);
+
+        // 위험 사유 조립
+        List<ChurnRiskReason> riskReasons = buildLogRiskReasons(events, snapshotContext.feature(), scoreResult);
+
+        // 스냅샷 저장
+        return churnSnapshotStoreService.store(memberId, baseDate, ChurnRiskReason.Feature.LOG, riskReasons);
+    }
+
+    /**
+     * 로그 사유 조립.
+     */
+    private List<ChurnRiskReason> buildLogRiskReasons(
+            List<LogFeatureEvent> events,
+            MemberActionFeature feature,
+            ChurnScoreCalculationResult scoreResult
+    ) {
+        List<LogFeatureEvent> comparisonEvents = filter(events, LogFeatureEventName.CLICK_COMPARE);
+        List<LogFeatureEvent> penaltyEvents = filter(events, LogFeatureEventName.CLICK_PENALTY);
+
+        return java.util.stream.Stream.of(
+                        buildLogReason(
+                                comparisonEvents,
+                                feature.comparisonCount(),
+                                scoreResult,
+                                ChurnRiskReason.ReasonCode.COMPARE,
+                                ChurnSignalType.COMPARISON_COUNT
+                        ),
+                        buildLogReason(
+                                penaltyEvents,
+                                feature.checkedPenaltyFeeCount(),
+                                scoreResult,
+                                ChurnRiskReason.ReasonCode.CHECKED_PENALTY_FEE,
+                                ChurnSignalType.CHECKED_PENALTY_FEE_COUNT
+                        )
+                )
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    /**
+     * 로그 사유.
+     */
+    private Optional<ChurnRiskReason> buildLogReason(
+            List<LogFeatureEvent> events,
+            int totalCount,
+            ChurnScoreCalculationResult scoreResult,
+            ChurnRiskReason.ReasonCode reasonCode,
+            ChurnSignalType signalType
+    ) {
+        if (events.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return churnRiskReasonFactory.create(
+                scoreResult,
+                ChurnRiskReason.Feature.LOG,
+                reasonCode,
+                signalType,
+                totalCount,
+                reasonCode.logSummary(totalCount),
+                new ChurnRiskReason.LogEvidence(
+                        events.size(),
+                        totalCount,
+                        toLogItems(events)
+                )
+        );
+    }
+
+    /**
+     * 이벤트 필터.
+     */
+    private List<LogFeatureEvent> filter(List<LogFeatureEvent> events, LogFeatureEventName eventName) {
+        return events.stream()
+                .filter(event -> event.eventName() == eventName)
+                .toList();
+    }
+
+    /**
+     * 이벤트 근거.
+     */
+    private List<ChurnRiskReason.LogEventItem> toLogItems(List<LogFeatureEvent> events) {
+        return events.stream()
+                .map(event -> new ChurnRiskReason.LogEventItem(
+                        event.eventId(),
+                        event.timestamp().toString(),
+                        event.event(),
+                        event.eventName().value(),
+                        event.eventProperties()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/site/holliverse/admin/application/usecase/ChurnRiskReason.java
+++ b/src/main/java/site/holliverse/admin/application/usecase/ChurnRiskReason.java
@@ -4,6 +4,7 @@ import site.holliverse.admin.domain.model.churn.ChurnFeatureCollectionType;
 import site.holliverse.admin.domain.model.churn.ChurnSignalType;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 이탈 위험 사유.
@@ -33,7 +34,9 @@ public record ChurnRiskReason(
      */
     public enum ReasonCode {
         NEGATIVE_SENTIMENT("부정 상담 감지"),
-        KEYWORD("상담 키워드 감지");
+        KEYWORD("상담 키워드 감지"),
+        COMPARE("요금제 비교 클릭 감지"),
+        CHECKED_PENALTY_FEE("위약금 확인 이력 클릭 감지");
 
         private final String defaultSummary;
 
@@ -82,6 +85,19 @@ public record ChurnRiskReason(
 
             return String.join(", ", labels) + " 키워드 감지";
         }
+
+        /**
+         * 로그 요약.
+         */
+        public String logSummary(int totalCount) {
+            String label = switch (this) {
+                case COMPARE -> "요금제 비교 클릭";
+                case CHECKED_PENALTY_FEE -> "위약금 확인 이력 클릭";
+                default -> defaultSummary;
+            };
+
+            return label + " 누적 " + totalCount + "회";
+        }
     }
 
     /**
@@ -122,5 +138,27 @@ public record ChurnRiskReason(
             }
             return keywordName + " " + count + "회";
         }
+    }
+
+    /**
+     * 로그 근거.
+     */
+    public record LogEvidence(
+            int incrementCount,
+            int totalCount,
+            List<LogEventItem> events
+    ) {
+    }
+
+    /**
+     * 로그 항목.
+     */
+    public record LogEventItem(
+            Long eventId,
+            String timestamp,
+            String event,
+            String eventName,
+            Map<String, Object> eventProperties
+    ) {
     }
 }

--- a/src/main/java/site/holliverse/admin/application/usecase/ChurnRiskReasonFactory.java
+++ b/src/main/java/site/holliverse/admin/application/usecase/ChurnRiskReasonFactory.java
@@ -1,0 +1,57 @@
+package site.holliverse.admin.application.usecase;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import site.holliverse.admin.domain.model.churn.ChurnFeatureContribution;
+import site.holliverse.admin.domain.model.churn.ChurnScoreCalculationResult;
+import site.holliverse.admin.domain.model.churn.ChurnSignalType;
+
+import java.util.Optional;
+
+/**
+ * 위험 사유 생성기.
+ */
+@Profile("admin")
+@Component
+public class ChurnRiskReasonFactory {
+
+    /**
+     * 사유 생성.
+     */
+    public Optional<ChurnRiskReason> create(
+            ChurnScoreCalculationResult scoreResult,
+            ChurnRiskReason.Feature feature,
+            ChurnRiskReason.ReasonCode reasonCode,
+            ChurnSignalType signalType,
+            Object observedValue,
+            String summary,
+            Object evidence
+    ) {
+        int appliedScore = appliedScore(scoreResult, signalType);
+        if (appliedScore <= 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new ChurnRiskReason(
+                feature,
+                reasonCode,
+                summary,
+                appliedScore,
+                signalType,
+                signalType.getCollectionType(),
+                observedValue,
+                evidence
+        ));
+    }
+
+    /**
+     * signal 점수.
+     */
+    private int appliedScore(ChurnScoreCalculationResult scoreResult, ChurnSignalType signalType) {
+        return scoreResult.contributions().stream()
+                .filter(contribution -> contribution.signalType() == signalType)
+                .mapToInt(ChurnFeatureContribution::appliedScore)
+                .findFirst()
+                .orElse(0);
+    }
+}

--- a/src/main/java/site/holliverse/admin/application/usecase/ChurnSnapshotStoreService.java
+++ b/src/main/java/site/holliverse/admin/application/usecase/ChurnSnapshotStoreService.java
@@ -2,22 +2,30 @@ package site.holliverse.admin.application.usecase;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
+import org.jooq.Record2;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import site.holliverse.admin.domain.model.churn.ChurnFeatureContribution;
-import site.holliverse.admin.domain.model.churn.ChurnFeatureType;
+import site.holliverse.admin.domain.model.churn.ChurnEvaluationResult;
 import site.holliverse.admin.domain.model.churn.ChurnRiskGrade;
+import site.holliverse.admin.domain.model.churn.ChurnScore;
 import site.holliverse.admin.domain.model.churn.ChurnScoreCalculationResult;
+import site.holliverse.admin.domain.policy.churn.ChurnRiskGradePolicy;
+import site.holliverse.admin.query.jooq.enums.FeatureType;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 import static site.holliverse.admin.query.jooq.Tables.CHURN_FEATURE_SCORE;
 import static site.holliverse.admin.query.jooq.Tables.CHURN_SCORE_SNAPSHOT;
+import static site.holliverse.admin.query.jooq.Tables.FEATURE_SNAPSHOT_STORE;
 
 @Service
 @Profile("admin")
@@ -26,32 +34,47 @@ public class ChurnSnapshotStoreService {
 
     private final DSLContext dsl;
     private final ObjectMapper objectMapper;
+    private final ChurnRiskGradePolicy churnRiskGradePolicy;
 
+    /**
+     * 스냅샷 저장.
+     */
     @Transactional
-    public void store(
+    public ChurnEvaluationResult store(
             Long memberId,
             LocalDate baseDate,
-            ChurnScoreCalculationResult result,
-            ChurnRiskGrade grade,
+            ChurnRiskReason.Feature updatedFeature,
             List<ChurnRiskReason> riskReasons
     ) {
-        // 위험 사유 직렬화
-        JSONB riskReasonsJson = JSONB.valueOf(writeRiskReasons(riskReasons));
-
         // 상세 점수
-        FeatureScores featureScores = toFeatureScores(result);
+        FeatureScores featureScores = readLatestFeatureScores(memberId);
+
+        // 총점 계산
+        ChurnScore churnScore = ChurnScore.fromRaw(featureScores.totalScore());
+        int totalScore = churnScore.value();
+
+        // 등급 계산
+        ChurnRiskGrade riskGrade = churnRiskGradePolicy.classify(totalScore);
+
+        // 위험 사유 직렬화
+        JSONB riskReasonsJson = JSONB.valueOf(writeRiskReasons(mergeRiskReasons(
+                memberId,
+                baseDate,
+                updatedFeature,
+                riskReasons
+        )));
 
         // 부모 업서트
         Long snapshotId = dsl.insertInto(CHURN_SCORE_SNAPSHOT)
                 .set(CHURN_SCORE_SNAPSHOT.MEMBER_ID, memberId)
-                .set(CHURN_SCORE_SNAPSHOT.CHURN_SCORE, result.score().value())
-                .set(CHURN_SCORE_SNAPSHOT.RISK_LEVEL, grade.name())
+                .set(CHURN_SCORE_SNAPSHOT.CHURN_SCORE, totalScore)
+                .set(CHURN_SCORE_SNAPSHOT.RISK_LEVEL, riskGrade.name())
                 .set(CHURN_SCORE_SNAPSHOT.RISK_REASONS, riskReasonsJson)
                 .set(CHURN_SCORE_SNAPSHOT.BASE_DATE, baseDate)
                 .onConflict(CHURN_SCORE_SNAPSHOT.MEMBER_ID, CHURN_SCORE_SNAPSHOT.BASE_DATE)
                 .doUpdate()
-                .set(CHURN_SCORE_SNAPSHOT.CHURN_SCORE, result.score().value())
-                .set(CHURN_SCORE_SNAPSHOT.RISK_LEVEL, grade.name())
+                .set(CHURN_SCORE_SNAPSHOT.CHURN_SCORE, totalScore)
+                .set(CHURN_SCORE_SNAPSHOT.RISK_LEVEL, riskGrade.name())
                 .set(CHURN_SCORE_SNAPSHOT.RISK_REASONS, riskReasonsJson)
                 .returning(CHURN_SCORE_SNAPSHOT.SNAPSHOT_ID)
                 .fetchOne(CHURN_SCORE_SNAPSHOT.SNAPSHOT_ID);
@@ -70,39 +93,115 @@ public class ChurnSnapshotStoreService {
                 .set(CHURN_FEATURE_SCORE.CHURN_COUNSEL_SCORE, featureScores.counselScore())
                 .set(CHURN_FEATURE_SCORE.CHURN_LOG_SCORE, featureScores.logScore())
                 .execute();
-    }
 
-    /**
-     * 상세 점수 조립.
-     */
-    private FeatureScores toFeatureScores(ChurnScoreCalculationResult result) {
-        return new FeatureScores(
-                toShortScore(result, ChurnFeatureType.CONTRACT),
-                toShortScore(result, ChurnFeatureType.USAGE),
-                toShortScore(result, ChurnFeatureType.MEMBER_DISSATISFACTION),
-                toShortScore(result, ChurnFeatureType.MEMBER_ACTION)
+        return new ChurnEvaluationResult(
+                new ChurnScoreCalculationResult(churnScore, List.of()),
+                riskGrade
         );
     }
 
     /**
-     * feature 점수.
+     * 최신 점수 조회.
      */
-    private Short toShortScore(ChurnScoreCalculationResult result, ChurnFeatureType featureType) {
-        // feature 합계
-        int featureScore = result.contributions().stream()
-                .filter(contribution -> contribution.featureType() == featureType)
-                .mapToInt(ChurnFeatureContribution::appliedScore)
-                .sum();
+    private FeatureScores readLatestFeatureScores(Long memberId) {
+        Map<FeatureType, Integer> latestScores = new EnumMap<>(FeatureType.class);
 
-        return (short) featureScore;
+        List<Record2<FeatureType, Integer>> records = dsl.select(
+                        FEATURE_SNAPSHOT_STORE.FEATURE_TYPE,
+                        FEATURE_SNAPSHOT_STORE.FEATURE_SCORE
+                )
+                .from(FEATURE_SNAPSHOT_STORE)
+                .where(FEATURE_SNAPSHOT_STORE.MEMBER_ID.eq(memberId))
+                .orderBy(FEATURE_SNAPSHOT_STORE.UPDATED_AT.desc())
+                .fetch();
+
+        for (Record2<FeatureType, Integer> record : records) {
+            latestScores.putIfAbsent(
+                    record.get(FEATURE_SNAPSHOT_STORE.FEATURE_TYPE),
+                    record.get(FEATURE_SNAPSHOT_STORE.FEATURE_SCORE)
+            );
+        }
+
+        return new FeatureScores(
+                toShortScore(latestScores.get(FeatureType.CONTRACT_FEATURE)),
+                toShortScore(latestScores.get(FeatureType.USAGE_FEATURE)),
+                toShortScore(latestScores.get(FeatureType.DISSATISFACTION_FEATURE)),
+                toShortScore(latestScores.get(FeatureType.MEMBER_ACTION_FEATURE))
+        );
     }
 
+    /**
+     * 위험 사유 병합.
+     */
+    private List<ChurnRiskReason> mergeRiskReasons(
+            Long memberId,
+            LocalDate baseDate,
+            ChurnRiskReason.Feature updatedFeature,
+            List<ChurnRiskReason> riskReasons
+    ) {
+        List<ChurnRiskReason> merged = new ArrayList<>();
+        readRiskReasons(memberId, baseDate).stream()
+                .filter(reason -> reason.feature() != updatedFeature)
+                .forEach(merged::add);
+        merged.addAll(riskReasons);
+        return merged;
+    }
+
+    /**
+     * 기존 사유 조회.
+     */
+    private List<ChurnRiskReason> readRiskReasons(Long memberId, LocalDate baseDate) {
+        JSONB riskReasonsJson = dsl.select(CHURN_SCORE_SNAPSHOT.RISK_REASONS)
+                .from(CHURN_SCORE_SNAPSHOT)
+                .where(CHURN_SCORE_SNAPSHOT.MEMBER_ID.eq(memberId))
+                .and(CHURN_SCORE_SNAPSHOT.BASE_DATE.eq(baseDate))
+                .fetchOptional(CHURN_SCORE_SNAPSHOT.RISK_REASONS)
+                .orElse(null);
+
+        if (riskReasonsJson == null || riskReasonsJson.data() == null || riskReasonsJson.data().isBlank()) {
+            return List.of();
+        }
+
+        try {
+            JsonNode root = objectMapper.readTree(riskReasonsJson.data());
+            if (!root.isArray()) {
+                return List.of();
+            }
+
+            List<ChurnRiskReason> reasons = new ArrayList<>();
+            for (JsonNode item : root) {
+                if (!item.isObject()) {
+                    continue;
+                }
+
+                try {
+                    reasons.add(objectMapper.convertValue(item, ChurnRiskReason.class));
+                } catch (IllegalArgumentException ignored) {
+                    // 구형 포맷 무시
+                }
+            }
+            return reasons;
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("risk reasons deserialization failed", e);
+        }
+    }
+
+    /**
+     * 위험 사유 직렬화.
+     */
     private String writeRiskReasons(List<ChurnRiskReason> riskReasons) {
         try {
             return objectMapper.writeValueAsString(riskReasons);
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("risk reasons serialization failed", e);
         }
+    }
+
+    /**
+     * 점수 변환.
+     */
+    private Short toShortScore(Integer featureScore) {
+        return featureScore == null ? 0 : featureScore.shortValue();
     }
 
     /**
@@ -114,5 +213,18 @@ public class ChurnSnapshotStoreService {
             Short counselScore,
             Short logScore
     ) {
+        /**
+         * 총점 합계.
+         */
+        private int totalScore() {
+            return score(baseScore) + score(usageScore) + score(counselScore) + score(logScore);
+        }
+
+        /**
+         * 점수 계산.
+         */
+        private int score(Short value) {
+            return value == null ? 0 : value;
+        }
     }
 }

--- a/src/main/java/site/holliverse/admin/application/usecase/LogFeatureEvent.java
+++ b/src/main/java/site/holliverse/admin/application/usecase/LogFeatureEvent.java
@@ -1,0 +1,16 @@
+package site.holliverse.admin.application.usecase;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * 로그 이벤트.
+ */
+public record LogFeatureEvent(
+        long eventId,
+        Instant timestamp,
+        String event,
+        LogFeatureEventName eventName,
+        Map<String, Object> eventProperties
+) {
+}

--- a/src/main/java/site/holliverse/admin/application/usecase/LogFeatureEventName.java
+++ b/src/main/java/site/holliverse/admin/application/usecase/LogFeatureEventName.java
@@ -1,0 +1,34 @@
+package site.holliverse.admin.application.usecase;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * 로그 이벤트명.
+ */
+public enum LogFeatureEventName {
+    CLICK_COMPARE("click_compare"),
+    CLICK_PENALTY("click_penalty");
+
+    private final String value;
+
+    LogFeatureEventName(String value) {
+        this.value = value;
+    }
+
+    /**
+     * 원본 값.
+     */
+    public String value() {
+        return value;
+    }
+
+    /**
+     * 이벤트 조회.
+     */
+    public static Optional<LogFeatureEventName> find(String value) {
+        return Arrays.stream(values())
+                .filter(eventName -> eventName.value.equals(value))
+                .findFirst();
+    }
+}

--- a/src/main/java/site/holliverse/admin/application/usecase/LogFeaturesUseCase.java
+++ b/src/main/java/site/holliverse/admin/application/usecase/LogFeaturesUseCase.java
@@ -5,13 +5,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import site.holliverse.admin.query.dao.MemberActionFeatureLogDao;
+import site.holliverse.admin.domain.model.churn.ChurnEvaluationResult;
 import site.holliverse.admin.web.dto.log.LogFeaturesRequestDto;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * POST /api/v1/admin/log-features 처리.
- * 스냅샷 조회/생성 정책: 해당 회원의 MEMBER_ACTION_FEATURE 최신 스냅샷을 쓰고, 없으면 1건 생성 후
- * comparison_cnt / checked_penalty_fee_cnt 만 증분 갱신.
  */
 @Service
 @Profile("admin")
@@ -19,24 +24,65 @@ import site.holliverse.admin.web.dto.log.LogFeaturesRequestDto;
 @Slf4j
 public class LogFeaturesUseCase {
 
-    private final MemberActionFeatureLogDao memberActionFeatureLogDao;
+    private final CalculateLogChurnScoreService calculateLogChurnScoreService;
 
     /**
-     * 요청대로 member_action_feature 카운트만 증분 반영.
-     * 스냅샷이 없으면 정책에 따라 생성 후 갱신.
+     * 로그 처리.
      */
     @Transactional
     public void execute(LogFeaturesRequestDto request) {
-        long snapshotId = memberActionFeatureLogDao.getOrCreateSnapshotId(request.memberId());
-        int updated = memberActionFeatureLogDao.incrementCounts(
-                snapshotId,
-                request.comparisonIncrement(),
-                request.penaltyIncrement()
-        );
-        if (updated > 0) {
-            log.debug("log-features: member_id={}, snapshot_id={}, comparison+{}, penalty+{}",
-                    request.memberId(), snapshotId,
-                    request.comparisonIncrement(), request.penaltyIncrement());
+        // 대상 이벤트
+        List<LogFeatureEvent> events = resolveEvents(request);
+        if (events.isEmpty()) {
+            log.debug("log-features skipped: member_id={} events=0", request.memberId());
+            return;
         }
+
+        // 기준일 추출
+        LocalDate baseDate = resolveBaseDate(events);
+
+        // 이탈률 계산
+        ChurnEvaluationResult result = calculateLogChurnScoreService.calculateAndStore(
+                request.memberId(),
+                baseDate,
+                events
+        );
+
+        log.debug("log-features: member_id={} events={} churnScore={}",
+                request.memberId(), events.size(), result.scoreResult().score().value());
+    }
+
+    /**
+     * 이벤트 변환.
+     */
+    private List<LogFeatureEvent> resolveEvents(LogFeaturesRequestDto request) {
+        Map<Long, LogFeatureEvent> events = new LinkedHashMap<>();
+        for (LogFeaturesRequestDto.LogEventDto event : request.events()) {
+            LogFeatureEventName.find(event.eventName())
+                    .ifPresent(eventName -> events.putIfAbsent(
+                            event.eventId(),
+                            new LogFeatureEvent(
+                                    event.eventId(),
+                                    Instant.parse(event.timestamp()),
+                                    event.event(),
+                                    eventName,
+                                    event.eventProperties()
+                            )
+                    ));
+        }
+
+        return List.copyOf(events.values());
+    }
+
+    /**
+     * 기준일 추출.
+     */
+    private LocalDate resolveBaseDate(List<LogFeatureEvent> events) {
+        return events.stream()
+                .map(LogFeatureEvent::timestamp)
+                .max(Instant::compareTo)
+                .orElseGet(Instant::now)
+                .atZone(ZoneId.of("Asia/Seoul"))
+                .toLocalDate();
     }
 }

--- a/src/main/java/site/holliverse/admin/application/usecase/MemberActionFeatureSnapshotService.java
+++ b/src/main/java/site/holliverse/admin/application/usecase/MemberActionFeatureSnapshotService.java
@@ -1,0 +1,77 @@
+package site.holliverse.admin.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import site.holliverse.admin.domain.model.churn.ChurnFeatureContribution;
+import site.holliverse.admin.domain.model.churn.ChurnFeatureType;
+import site.holliverse.admin.domain.model.churn.ChurnScoreCalculationResult;
+import site.holliverse.admin.domain.model.churn.feature.MemberActionFeature;
+import site.holliverse.admin.query.dao.MemberActionFeatureLogDao;
+
+import java.util.List;
+
+/**
+ * 로그 feature 스냅샷 서비스.
+ */
+@Service
+@Profile("admin")
+@RequiredArgsConstructor
+public class MemberActionFeatureSnapshotService {
+
+    private final MemberActionFeatureLogDao snapshotDao;
+
+    /**
+     * 스냅샷 준비.
+     */
+    public SnapshotContext prepare(Long memberId, List<LogFeatureEvent> events) {
+        MemberActionFeatureLogDao.ActionSnapshot snapshot = snapshotDao.getOrCreateSnapshot(memberId);
+
+        MemberActionFeature updatedFeature = new MemberActionFeature(
+                snapshot.feature().changeMobileCount(),
+                snapshot.feature().comparisonCount() + count(events, LogFeatureEventName.CLICK_COMPARE),
+                snapshot.feature().checkedPenaltyFeeCount() + count(events, LogFeatureEventName.CLICK_PENALTY)
+        );
+
+        return new SnapshotContext(snapshot.snapshotId(), updatedFeature);
+    }
+
+    /**
+     * 스냅샷 동기화.
+     */
+    public void sync(SnapshotContext context, ChurnScoreCalculationResult scoreResult) {
+        snapshotDao.syncSnapshot(
+                context.snapshotId(),
+                resolveFeatureScore(scoreResult),
+                context.feature()
+        );
+    }
+
+    /**
+     * feature 점수.
+     */
+    private int resolveFeatureScore(ChurnScoreCalculationResult scoreResult) {
+        return scoreResult.contributions().stream()
+                .filter(contribution -> contribution.featureType() == ChurnFeatureType.MEMBER_ACTION)
+                .mapToInt(ChurnFeatureContribution::appliedScore)
+                .sum();
+    }
+
+    /**
+     * 이벤트 개수.
+     */
+    private int count(List<LogFeatureEvent> events, LogFeatureEventName eventName) {
+        return (int) events.stream()
+                .filter(event -> event.eventName() == eventName)
+                .count();
+    }
+
+    /**
+     * 스냅샷 문맥.
+     */
+    public record SnapshotContext(
+            Long snapshotId,
+            MemberActionFeature feature
+    ) {
+    }
+}

--- a/src/main/java/site/holliverse/admin/query/dao/MemberActionFeatureLogDao.java
+++ b/src/main/java/site/holliverse/admin/query/dao/MemberActionFeatureLogDao.java
@@ -1,14 +1,13 @@
 package site.holliverse.admin.query.dao;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
 import org.jooq.DSLContext;
 import org.jooq.Sequence;
-import org.jooq.impl.DSL;
+import org.springframework.context.annotation.Profile;
+import site.holliverse.admin.domain.model.churn.feature.MemberActionFeature;
+import site.holliverse.admin.query.jooq.enums.FeatureType;
 
 import java.util.Optional;
-
-import site.holliverse.admin.query.jooq.enums.FeatureType;
 
 import static org.jooq.impl.DSL.currentLocalDateTime;
 import static org.jooq.impl.DSL.sequence;
@@ -16,9 +15,7 @@ import static site.holliverse.admin.query.jooq.Tables.FEATURE_SNAPSHOT_STORE;
 import static site.holliverse.admin.query.jooq.Tables.MEMBER_ACTION_FEATURE;
 
 /**
- * member_action_feature의 comparison_cnt / checked_penalty_fee_cnt 실시간 증분 갱신용 DAO.
- * feature_snapshot_store에서 해당 회원·MEMBER_ACTION_FEATURE 최신 스냅샷 조회 후 갱신.
- * 스냅샷 없을 때 생성 정책: 시퀀스로 새 ID 발급 후 feature_snapshot_store + member_action_feature 1건씩 INSERT.
+ * 로그 feature 스냅샷 DAO.
  */
 @Profile("admin")
 @RequiredArgsConstructor
@@ -30,7 +27,7 @@ public class MemberActionFeatureLogDao {
     private final DSLContext dsl;
 
     /**
-     * member_id + MEMBER_ACTION_FEATURE 기준 최신 스냅샷 ID 조회 (updated_at 내림차순 1건).
+     * 최신 스냅샷 조회.
      */
     public Optional<Long> findLatestSnapshotId(Long memberId) {
         return dsl
@@ -44,35 +41,43 @@ public class MemberActionFeatureLogDao {
     }
 
     /**
-     * member_action_feature의 comparison_cnt, checked_penalty_fee_cnt에 증분 반영.
+     * 스냅샷 조회.
      */
-    public int incrementCounts(Long featureSnapshotId, int comparisonIncrement, int penaltyIncrement) {
-        if (comparisonIncrement == 0 && penaltyIncrement == 0) {
-            return 0;
-        }
-        var ma = MEMBER_ACTION_FEATURE;
-        var update = dsl.update(ma)
-                .set(ma.COMPARISON_CNT, ma.COMPARISON_CNT.plus(comparisonIncrement))
-                .set(ma.CHECKED_PENALTY_FEE_CNT, ma.CHECKED_PENALTY_FEE_CNT.plus(penaltyIncrement))
-                .where(ma.FEATURE_SNAPSHOT_ID.eq(featureSnapshotId));
-        return update.execute();
+    public ActionSnapshot findSnapshot(Long snapshotId) {
+        return dsl.select(
+                        MEMBER_ACTION_FEATURE.FEATURE_SNAPSHOT_ID,
+                        MEMBER_ACTION_FEATURE.CHANGE_MOBILE_CNT,
+                        MEMBER_ACTION_FEATURE.COMPARISON_CNT,
+                        MEMBER_ACTION_FEATURE.CHECKED_PENALTY_FEE_CNT
+                )
+                .from(MEMBER_ACTION_FEATURE)
+                .where(MEMBER_ACTION_FEATURE.FEATURE_SNAPSHOT_ID.eq(snapshotId))
+                .fetchOptional(record -> new ActionSnapshot(
+                        record.get(MEMBER_ACTION_FEATURE.FEATURE_SNAPSHOT_ID),
+                        new MemberActionFeature(
+                                Optional.ofNullable(record.get(MEMBER_ACTION_FEATURE.CHANGE_MOBILE_CNT))
+                                        .map(Short::intValue)
+                                        .orElse(0),
+                                Optional.ofNullable(record.get(MEMBER_ACTION_FEATURE.COMPARISON_CNT))
+                                        .orElse(0),
+                                Optional.ofNullable(record.get(MEMBER_ACTION_FEATURE.CHECKED_PENALTY_FEE_CNT))
+                                        .orElse(0)
+                        )
+                ))
+                .orElseThrow(() -> new IllegalStateException("member action snapshot not found. snapshotId=" + snapshotId));
     }
 
     /**
-     * 스냅샷 조회/생성 정책: 최신 스냅샷이 있으면 그 ID, 없으면 1건 생성 후 해당 ID 반환.
-     * (최신 = member_id + MEMBER_ACTION_FEATURE, updated_at 내림차순 1건)
+     * 스냅샷 조회 또는 생성.
      */
-    public long getOrCreateSnapshotId(Long memberId) {
-        return findLatestSnapshotId(memberId)
+    public ActionSnapshot getOrCreateSnapshot(Long memberId) {
+        long snapshotId = findLatestSnapshotId(memberId)
                 .orElseGet(() -> createSnapshotForMemberActionFeature(memberId));
+        return findSnapshot(snapshotId);
     }
 
     /**
-     * 해당 회원의 MEMBER_ACTION_FEATURE 스냅샷이 없을 때 1건 생성.
-     * feature_snapshot_id는 feature_snapshot_id_seq 시퀀스로 발급.
-     * member 테이블에 해당 member_id가 있어야 FK 제약으로 정상 동작.
-     *
-     * @return 새로 생성된 feature_snapshot_id
+     * 스냅샷 생성.
      */
     public long createSnapshotForMemberActionFeature(Long memberId) {
         Long snapshotId = dsl
@@ -94,5 +99,32 @@ public class MemberActionFeatureLogDao {
                 .set(MEMBER_ACTION_FEATURE.CHECKED_PENALTY_FEE_CNT, 0)
                 .execute();
         return snapshotId.longValue();
+    }
+
+    /**
+     * 스냅샷 동기화.
+     */
+    public void syncSnapshot(Long snapshotId, int featureScore, MemberActionFeature feature) {
+        dsl.update(FEATURE_SNAPSHOT_STORE)
+                .set(FEATURE_SNAPSHOT_STORE.UPDATED_AT, currentLocalDateTime())
+                .set(FEATURE_SNAPSHOT_STORE.FEATURE_SCORE, featureScore)
+                .where(FEATURE_SNAPSHOT_STORE.FEATURE_SNAPSHOT_ID.eq(snapshotId))
+                .execute();
+
+        dsl.update(MEMBER_ACTION_FEATURE)
+                .set(MEMBER_ACTION_FEATURE.CHANGE_MOBILE_CNT, (short) feature.changeMobileCount())
+                .set(MEMBER_ACTION_FEATURE.COMPARISON_CNT, feature.comparisonCount())
+                .set(MEMBER_ACTION_FEATURE.CHECKED_PENALTY_FEE_CNT, feature.checkedPenaltyFeeCount())
+                .where(MEMBER_ACTION_FEATURE.FEATURE_SNAPSHOT_ID.eq(snapshotId))
+                .execute();
+    }
+
+    /**
+     * 스냅샷 묶음.
+     */
+    public record ActionSnapshot(
+            Long snapshotId,
+            MemberActionFeature feature
+    ) {
     }
 }

--- a/src/main/java/site/holliverse/admin/web/controller/AdminLogFeatureController.java
+++ b/src/main/java/site/holliverse/admin/web/controller/AdminLogFeatureController.java
@@ -14,22 +14,21 @@ import site.holliverse.shared.web.response.ApiResponse;
 
 /**
  * 실시간 로그 기반 feature 카운트 갱신 API.
- * Customer API user-logs 처리 후 event_name dedupe 결과를 전달받아 member_action_feature만 갱신.
+ * Customer API user-logs 처리 후 event_id dedupe 결과를 전달받아
+ * member_action_feature와 churn snapshot을 갱신한다.
  */
 @Profile("admin")
 @RestController
-@RequestMapping("/api/v1/admin")
+@RequestMapping("/internal/v1/log-features")
 @RequiredArgsConstructor
 public class AdminLogFeatureController {
 
     private final LogFeaturesUseCase logFeaturesUseCase;
 
     /**
-     * 비교/패널티 건수 증분 반영.
-     * body: memberId, comparisonIncrement(0|1), penaltyIncrement(0|1).
-     * 해당 회원의 MEMBER_ACTION_FEATURE 스냅샷이 있을 때만 갱신, 없으면 스냅샷을 새로 생성
+     * 비교/위약금 이벤트 반영.
      */
-    @PostMapping("/log-features")
+    @PostMapping
     public ResponseEntity<ApiResponse<Void>> logFeatures(@Valid @RequestBody LogFeaturesRequestDto request) {
         logFeaturesUseCase.execute(request);
         return ResponseEntity.ok(ApiResponse.success("처리되었습니다.", null));

--- a/src/main/java/site/holliverse/admin/web/dto/log/LogFeaturesRequestDto.java
+++ b/src/main/java/site/holliverse/admin/web/dto/log/LogFeaturesRequestDto.java
@@ -1,30 +1,36 @@
 package site.holliverse.admin.web.dto.log;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * POST /api/v1/admin/log-features 요청 DTO.
- * user-logs 배치에서 event_name 기준 중복 제거 후, 비교/패널티 발생 시 각각 0 또는 1로 전달.
+ * user-logs 배치에서 event_id 기준 중복 제거 후, 비교/위약금 이벤트만 전달한다.
  */
 public record LogFeaturesRequestDto(
 
         @NotNull(message = "memberId는 필수입니다.")
         Long memberId,
 
-        /**
-         * 비교하기 클릭 건수 증분 (배치당 0 또는 1)
-         */
-        @Min(0)
-        @Max(1)
-        int comparisonIncrement,
-
-        /**
-         * 패널티 확인 건수 증분 (배치당 0 또는 1)
-         */
-        @Min(0)
-        @Max(1)
-        int penaltyIncrement
+        @NotEmpty(message = "events는 최소 1건 이상이어야 합니다.")
+        List<LogEventDto> events
 ) {
+    public record LogEventDto(
+            @Min(0)
+            long eventId,
+            @NotBlank(message = "timestamp는 필수입니다.")
+            String timestamp,
+            @NotBlank(message = "event는 필수입니다.")
+            String event,
+            @NotBlank(message = "eventName은 필수입니다.")
+            String eventName,
+            @NotNull(message = "eventProperties는 필수입니다.")
+            Map<String, Object> eventProperties
+    ) {
+    }
 }

--- a/src/main/java/site/holliverse/customer/application/usecase/log/UserLogService.java
+++ b/src/main/java/site/holliverse/customer/application/usecase/log/UserLogService.java
@@ -16,7 +16,9 @@ import site.holliverse.customer.web.dto.log.UserLogRequest;
 import site.holliverse.shared.error.CustomException;
 import site.holliverse.shared.error.ErrorCode;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -39,19 +41,17 @@ public class UserLogService {
         for (UserLogRequest request : requests) {
             doPublish(memberId, request);
         }
-        // event_name 기준 배치 내 중복 제거 후 Admin log-features 호출 (comparison/penalty 각 최대 1)
-        int comparisonIncrement = requests.stream()
-                .anyMatch(r -> UserLogEventName.CLICK_COMPARE.value().equals(r.eventName())) ? 1 : 0;
-        int penaltyIncrement = requests.stream()
-                .anyMatch(r -> UserLogEventName.CLICK_PENALTY.value().equals(r.eventName())) ? 1 : 0;
-        if (comparisonIncrement != 0 || penaltyIncrement != 0) {
-            adminLogFeaturesClient.sendLogFeatures(memberId, comparisonIncrement, penaltyIncrement);
-        }
+
+        // 이벤트 전달
+        adminLogFeaturesClient.sendLogFeatures(memberId, toAdminEvents(requests));
     }
 
     @Async("userLogTaskExecutor")
     public void publish(Long memberId, UserLogRequest request) {
         doPublish(memberId, request);
+
+        // 이벤트 전달
+        adminLogFeaturesClient.sendLogFeatures(memberId, toAdminEvents(List.of(request)));
     }
 
     /**
@@ -109,5 +109,39 @@ public class UserLogService {
         Tsid parsed = Tsid.from(tsid);
         return parsed.toLong();
     }
-}
 
+    /**
+     * Admin 이벤트 변환.
+     */
+    private List<AdminLogFeaturesClient.LogEventBody> toAdminEvents(List<UserLogRequest> requests) {
+        Map<Long, AdminLogFeaturesClient.LogEventBody> deduplicatedEvents = new LinkedHashMap<>();
+        for (UserLogRequest request : requests) {
+            UserLogEventName eventName = UserLogEventName.from(request.eventName());
+            if (!isAdminTarget(eventName)) {
+                continue;
+            }
+
+            long eventId = decodeTsidToLong(request.tsid());
+            deduplicatedEvents.putIfAbsent(
+                    eventId,
+                    new AdminLogFeaturesClient.LogEventBody(
+                            eventId,
+                            request.timestamp(),
+                            request.event(),
+                            eventName.value(),
+                            request.eventProperties()
+                    )
+            );
+        }
+
+        return List.copyOf(deduplicatedEvents.values());
+    }
+
+    /**
+     * 대상 이벤트.
+     */
+    private boolean isAdminTarget(UserLogEventName eventName) {
+        return eventName == UserLogEventName.CLICK_COMPARE
+                || eventName == UserLogEventName.CLICK_PENALTY;
+    }
+}

--- a/src/main/java/site/holliverse/customer/config/AdminLogFeaturesProperties.java
+++ b/src/main/java/site/holliverse/customer/config/AdminLogFeaturesProperties.java
@@ -3,7 +3,7 @@ package site.holliverse.customer.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * Admin API log-features 호출 설정. application*.yml의 app.admin과 바인딩.
+ * Admin 내부 log-features 호출 설정. application*.yml의 app.admin과 바인딩.
  * base-url이 비어 있으면 HTTP 호출을 하지 않음(no-op).
  */
 @ConfigurationProperties(prefix = "app.admin")
@@ -17,7 +17,7 @@ public record AdminLogFeaturesProperties(
         if (connectTimeoutMs <= 0) connectTimeoutMs = 3_000;
         if (readTimeoutMs <= 0) readTimeoutMs = 5_000;
         if (logFeaturesPath == null || logFeaturesPath.isBlank()) {
-            logFeaturesPath = "/api/v1/admin/log-features";
+            logFeaturesPath = "/internal/v1/log-features";
         }
     }
 

--- a/src/main/java/site/holliverse/customer/integration/external/AdminLogFeaturesClient.java
+++ b/src/main/java/site/holliverse/customer/integration/external/AdminLogFeaturesClient.java
@@ -9,8 +9,11 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import site.holliverse.customer.config.AdminLogFeaturesProperties;
 
+import java.util.List;
+import java.util.Map;
+
 /**
- * Admin API POST /api/v1/admin/log-features 호출용 클라이언트.
+ * Admin API POST /internal/v1/log-features 호출용 클라이언트.
  * customer 모듈은 admin 패키지를 의존하지 않고 HTTP만 사용(ArchUnit 준수).
  */
 @Slf4j
@@ -31,15 +34,15 @@ public class AdminLogFeaturesClient {
      * log-features API 호출. baseUrl이 비어 있으면 호출하지 않음(no-op).
      * 실패 시 로깅만 하고 예외 전파하지 않음(배치 처리 방해 방지).
      */
-    public void sendLogFeatures(long memberId, int comparisonIncrement, int penaltyIncrement) {
-        if (baseUrl == null || baseUrl.isBlank()) {
+    public void sendLogFeatures(long memberId, List<LogEventBody> events) {
+        if (baseUrl == null || baseUrl.isBlank() || events == null || events.isEmpty()) {
             return;
         }
         String path = (logFeaturesPath != null && !logFeaturesPath.isBlank())
                 ? logFeaturesPath
-                : "/api/v1/admin/log-features";
+                : "/internal/v1/log-features";
         String url = baseUrl + path;
-        LogFeaturesRequestBody body = new LogFeaturesRequestBody(memberId, comparisonIncrement, penaltyIncrement);
+        LogFeaturesRequestBody body = new LogFeaturesRequestBody(memberId, events);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<LogFeaturesRequestBody> entity = new HttpEntity<>(body, headers);
@@ -54,5 +57,19 @@ public class AdminLogFeaturesClient {
     }
 
     /** Admin API 요청 body (admin 패키지 미참조). */
-    public record LogFeaturesRequestBody(long memberId, int comparisonIncrement, int penaltyIncrement) {}
+    public record LogFeaturesRequestBody(
+            long memberId,
+            List<LogEventBody> events
+    ) {
+    }
+
+    /** Admin API 로그 body. */
+    public record LogEventBody(
+            long eventId,
+            String timestamp,
+            String event,
+            String eventName,
+            Map<String, Object> eventProperties
+    ) {
+    }
 }


### PR DESCRIPTION
## 📝작업 내용
- customer에서 churn 대상 로그 2종을 admin 내부 API로 HTTP 전송하도록 변경했습니다.
- admin에서 로그 이벤트를 `member_action_feature`, `feature_snapshot_store`에 반영하도록 구현했습니다.
- 로그 기반 이탈 위험 사유를 공통 `risk_reasons` 포맷으로 저장하도록 구현했습니다.
- 상담/로그가 같은 날짜 `churn_score_snapshot`을 공유하더라도 서로 덮어쓰지 않도록 feature별 사유 병합 및 총점 재집계 구조로 변경했습니다.
- 로그 수신 경로를 내부 전용 `/internal/v1/log-features`로 변경했습니다.

<br/>

## 👀변경 사항

### 변경 요약
| 구분 | 변경 내용 | 비고 |
| --- | --- | --- |
| 수신 경로 | `/api/v1/admin/log-features` -> `/internal/v1/log-features` | 내부 전용 경로 |
| customer 전송 | `click_compare`, `click_penalty`만 admin으로 HTTP 전송 | `event_id` 기준 dedupe |
| 요청 포맷 | 증분값 DTO -> 이벤트 목록 DTO | `memberId + events[]` |
| feature 저장 | `member_action_feature`, `feature_snapshot_store` 동기화 | `comparison_cnt`, `checked_penalty_fee_cnt` 반영 |
| churn 저장 | `churn_score_snapshot`, `churn_feature_score` 동기화 | 로그 점수 포함 재집계 |
| 위험 사유 | 공통 `ChurnRiskReason` 포맷 확장 | `LOG / COMPARE / CHECKED_PENALTY_FEE` 추가 |
| 병합 정책 | 상담 사유 유지 + 로그 사유 병합 | 같은 `member_id + base_date` 기준 |

### 대상 로그
| event_name | 의미 | 반영 컬럼 | signal_type |
| --- | --- | --- | --- |
| `click_compare` | 요금제 비교 클릭 | `comparison_cnt` | `COMPARISON_COUNT` |
| `click_penalty` | 위약금 확인 이력 클릭 | `checked_penalty_fee_cnt` | `CHECKED_PENALTY_FEE_COUNT` |

### 저장 결과
| 테이블 | 반영 내용 |
| --- | --- |
| `feature_snapshot_store` | `MEMBER_ACTION_FEATURE` 최신 점수 저장 |
| `member_action_feature` | 로그 누적 count 저장 |
| `churn_score_snapshot` | 상담 점수 + 로그 점수 합산 총점 저장 |
| `churn_feature_score` | `churn_log_score` 분리 저장 |
| `churn_score_snapshot.risk_reasons` | 상담 사유 + 로그 사유 공통 포맷 병합 저장 |

### 주요 구현 파일
| 파일 | 역할 |
| --- | --- |
| `UserLogService` | customer 로그 중 admin 대상 이벤트 추출 |
| `AdminLogFeaturesClient` | admin 내부 HTTP 호출 |
| `AdminLogFeatureController` | `/internal/v1/log-features` 수신 |
| `LogFeaturesUseCase` | 로그 이벤트 변환 및 churn 계산 진입 |
| `CalculateLogChurnScoreService` | 로그 feature 기반 점수 계산 |
| `MemberActionFeatureSnapshotService` | 로그 feature snapshot 동기화 |
| `MemberActionFeatureLogDao` | `member_action_feature` / `feature_snapshot_store` 저장 |
| `ChurnSnapshotStoreService` | feature별 최신 점수 재집계 및 risk reason 병합 |
| `ChurnRiskReason` | 상담/로그 공통 위험 사유 포맷 |


### 다이어그램 1. customer -> admin 로그 파이프라인



```mermaid
flowchart LR
    A["Customer user log"] --> B["UserLogService"]
    B --> C["Kafka publish"]
    B --> D["AdminLogFeaturesClient"]
    D --> E["POST /internal/v1/log-features"]
    E --> F["AdminLogFeatureController"]
    F --> G["LogFeaturesUseCase"]

```

- customer는 전체 로그를 Kafka로 보내고,
- churn 대상 로그 2종만 별도로 admin 내부 HTTP로 전달

## 다이어그램 2. admin 로그 처리 흐름

```mermaid
flowchart TD
    A["LogFeaturesRequestDto"] --> B["LogFeaturesUseCase"]
    B --> C["LogFeatureEvent 변환"]
    C --> D["CalculateLogChurnScoreService"]
    D --> E["MemberActionFeatureSnapshotService"]
    E --> F["feature_snapshot_store"]
    E --> G["member_action_feature"]
    D --> H["ChurnSnapshotStoreService"]
    H --> I["churn_score_snapshot"]
    H --> J["churn_feature_score"]

```

1. 로그 이벤트를 domain 이벤트로 변환한 뒤,
2. 로그 feature snapshot을 먼저 갱신하고,
3. 그 결과를 포함해 최종 churn snapshot을 다시 저장



## 다이어그램 3. 상담/로그 스냅샷 병합 구조

```mermaid
flowchart LR
    A["DISSATISFACTION_FEATURE 최신 점수"] --> C["ChurnSnapshotStoreService"]
    B["MEMBER_ACTION_FEATURE 최신 점수"] --> C
    C --> D["총점 재집계"]
    C --> E["risk_reasons feature별 병합"]
    D --> F["churn_score_snapshot"]
    E --> F
    C --> G["churn_feature_score"]

```

1. 같은 날짜 snapshot을 feature별로 나눠 따로 저장하지 않고,
2. 최신 feature snapshot 점수를 다시 합산해 churn_score_snapshot에 반영
3. risk_reasons는 현재 업데이트하는 feature만 교체하고, 다른 feature 사유는 유지

## 🎫 Jira Ticket
- Jira Ticket: HCR-335

<br/>

## #️⃣관련 이슈

- closes #231 


<br/>
